### PR TITLE
Pretty basic ami-frontend Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Bases the image on Ubuntu 16.04 (since 18.04 is still not available)
+FROM ubuntu:16.04
+
+# Basic update/upgrade mechanism + installs necessary packages
+RUN apt update && \
+    apt upgrade -y && \
+    apt install apt-transport-https ca-certificates nodejs npm -y
+
+# Install Bower & Grunt using npm
+RUN npm install -g bower grunt-cli
+
+# Defines the default work directory
+WORKDIR /data
+
+# Copies AMI files to the desired directory
+COPY . /data
+
+# Defines the default command to be run once container is up and running.
+# It will probably make sense to have "run.sh" which will actually define these.
+CMD ["nodejs", "-v"]


### PR DESCRIPTION
Dockerfile which installs `bower`, `grunt` and `npm` on top of Ubuntu 16.04.

To build it:

```bash
docker build -t ami-frontend .
``` 

...where "-t ami-frontend" adds a tag to the container so that it's easier to reference it (when running `docker run` for example). I've placed a comment above every single line in order to help you figure out which part does what. 

If I understand AMI ecosystem correctly, this container shouldn't actually run anything, it should just serve the front-end from `app/index.html` when the rest of the ecosystem is up and running?